### PR TITLE
html: simplify parser type  

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -15,9 +15,6 @@
   "imports": {
     "@std/assert": "jsr:@std/assert@1"
   },
-  "lint": {
-    "exclude": ["tests/html-parser/cases/**/*.html"]
-  },
   "publish": {
     "exclude": ["./tests/*"]
   }

--- a/examples/html.ts
+++ b/examples/html.ts
@@ -95,12 +95,12 @@ export const spacesAndComments: Parser<MSpacesAndComments> = sequence(
  *
  * https://html.spec.whatwg.org/#syntax-doctype
  */
-export const doctype: Parser<string> = sequence([
+export const doctype: Parser<MTextNode> = sequence([
   regex(/^<!DOCTYPE/i),
   whitespace.skip(whitespaces),
   regex(/^html/i).skip(whitespaces),
   literal(">"),
-]).map(() => "<!DOCTYPE html>").error("Expected a valid doctype");
+]).map(() => textNode("<!DOCTYPE html>")).error("Expected a valid doctype");
 
 const singleQuote = literal("'");
 const doubleQuote = literal('"');
@@ -284,24 +284,13 @@ export const shadowRoot: Parser<MFragment> = createParser(
  *
  * https://html.spec.whatwg.org/#writing
  */
-export const html: Parser<
-  [MCommentNode[], string, MCommentNode[], MElement, MCommentNode[]]
-> = sequence([
+export const html: Parser<MFragment> = sequence([
   spacesAndComments,
   doctype,
   spacesAndComments,
   element,
   spacesAndComments,
-])
-  .map((
-    [comments1, doctype, comments2, document, comments3],
-  ) => [
-    comments1.filter((c) => c.kind === "COMMENT"),
-    doctype,
-    comments2.filter((c) => c.kind === "COMMENT"),
-    document,
-    comments3.filter((c) => c.kind === "COMMENT"),
-  ]);
+]).map((fragments) => fragments.flat());
 
 /**
  * The monarch serialization options

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -103,7 +103,6 @@ Deno.test("comments_nested", () => {
           kind: Kind.NORMAL,
           attributes: [],
           children: [
-
             { kind: "TEXT", text: "\n        Some text\n        " },
             commentNode(" This is a button "),
             textNode("\n        "),
@@ -328,122 +327,27 @@ Deno.test("normal_element", () => {
   });
 });
 
-// Deno.test("significant_whitespace", () => {
-//   const collapsing_space = element.parseOrThrow(
-//     `<span>
-//     </span>`,
-//   );
-//   assertEquals(collapsing_space, {
-//     tagName: "span",
-//     kind: Kind.NORMAL,
-//     attributes: [],
-//     children: [
-//       { kind: "WHITESPACE" },
-//     ],
-//   });
+Deno.test("custom_elements", () => {
+  const res = fragments.parseOrThrow(`
+    <something-different>
+      <atom-text-editor mini>
+        Hello
+      </atom-text-editor>
+    </something-different>
+    `.trim());
 
-//   const surrounding_spaces = element.parseOrThrow(
-//     `<span>
-//     lorem
-//     </span>`,
-//   );
-//   assertEquals(surrounding_spaces, {
-//     tagName: "span",
-//     kind: Kind.NORMAL,
-//     attributes: [],
-//     children: [
-//       { kind: "WHITESPACE" },
-//       { kind: "TEXT", text: "lorem" },
-//       { kind: "WHITESPACE" },
-//     ],
-//   });
-// });
-
-// Deno.test("custom_elements", () => {
-//   const res = fragments.parseOrThrow(`
-//     <something-different>
-//       <atom-text-editor mini>
-//         Hello
-//       </atom-text-editor>
-//     </something-different>
-//     `.trim());
-
-//   assertEquals(res, [{
-//     tagName: "something-different",
-//     kind: Kind.CUSTOM,
-//     attributes: [],
-//     children: [WHITE_SPACE_NODE, {
-//       tagName: "atom-text-editor",
-//       kind: Kind.CUSTOM,
-//       attributes: [["mini", ""]],
-//       children: [WHITE_SPACE_NODE, textNode("Hello"), WHITE_SPACE_NODE],
-//     }, WHITE_SPACE_NODE],
-//   }]);
-// });
-
-// Deno.test("nested elements", () => {
-//   const nested = element.parseOrThrow(`
-//     <div>
-//       <p>
-//         <button>click</button>
-//       </p>
-//       <p>
-//         Multi-line
-//         text
-//       </p>
-//       <p>
-//         <input type="checkbox">
-//       </p>
-//     </div>
-//     `.trim());
-
-//   assertEquals(nested, {
-//     tagName: "div",
-//     kind: Kind.NORMAL,
-//     attributes: [],
-//     children: [
-//       WHITE_SPACE_NODE,
-//       {
-//         tagName: "p",
-//         kind: Kind.NORMAL,
-//         attributes: [],
-//         children: [WHITE_SPACE_NODE, {
-//           tagName: "button",
-//           kind: Kind.NORMAL,
-//           attributes: [],
-//           children: [textNode("click")],
-//         }, WHITE_SPACE_NODE],
-//       },
-//       WHITE_SPACE_NODE,
-//       {
-//         tagName: "p",
-//         kind: Kind.NORMAL,
-//         attributes: [],
-//         children: [
-//           WHITE_SPACE_NODE,
-//           textNode("Multi-line\n        text"),
-//           WHITE_SPACE_NODE,
-//         ],
-//       },
-//       WHITE_SPACE_NODE,
-//       {
-//         tagName: "p",
-//         kind: Kind.NORMAL,
-//         attributes: [],
-//         children: [
-//           WHITE_SPACE_NODE,
-//           {
-//             tagName: "input",
-//             kind: Kind.VOID,
-//             attributes: [["type", "checkbox"]],
-//           },
-//           WHITE_SPACE_NODE,
-//         ],
-//       },
-//       WHITE_SPACE_NODE,
-//     ],
-//   });
-// });
+  assertEquals(res, [{
+    tagName: "something-different",
+    kind: Kind.CUSTOM,
+    attributes: [],
+    children: [textNode("\n      "), {
+      tagName: "atom-text-editor",
+      kind: Kind.CUSTOM,
+      attributes: [["mini", ""]],
+      children: [textNode("\n        Hello\n      ")],
+    }, textNode("\n    ")],
+  }]);
+});
 
 Deno.test("entities", () => {
   const entities = fragments.parseOrThrow(`
@@ -495,7 +399,22 @@ Deno.test("serialize", () => {
 
   const spaces = `Hello, <a href="#"> World </a>!`;
 
-  for (const sample of [...samples, indentation, spaces]) {
+  const nested = `
+    <div>
+      <p>
+        <button>click</button>
+      </p>
+      <p>
+        Multi-line
+        text
+      </p>
+      <p>
+        <input type="checkbox">
+      </p>
+    </div>
+    `.trim();
+
+  for (const sample of [...samples, indentation, spaces, nested]) {
     assertEquals(serializeFragments(fragments.parseOrThrow(sample)), sample);
   }
 });

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -148,7 +148,7 @@ Deno.test("comments_nested", () => {
 Deno.test("doctype", () => {
   const res = doctype.parseOrThrow("<!Doctype Html >");
 
-  assertEquals(res, "<!DOCTYPE html>");
+  assertEquals(res, textNode("<!DOCTYPE html>"));
 });
 
 Deno.test("attributes", () => {


### PR DESCRIPTION
The main `html` parser now parses a `MFragment` when successful