### PR TITLE
add optional and defaulted

### DIFF
--- a/examples/common.ts
+++ b/examples/common.ts
@@ -129,6 +129,46 @@ export const takeTwo: Parser<string> = repeat(take, 2).map((arr) =>
 ).error(parseErrors.takeTwoError);
 
 /**
+ * Tries a parser or defaults to a value.
+ * @param parser The parser.
+ * @param value The default value.
+ * @returns A parser returning the successful parse result or the default value.
+ *
+ * @example
+ * ```ts
+ * const number = defaulted(digit, 42);
+ *
+ * number.parse("123");
+ * // [{ value: 1, remaining: "23", ... }]
+ * number.parse("abc");
+ * // [{ value: 42, remaining: "abc", ... }]
+ */
+export const defaulted = <T>(
+  parser: Parser<T>,
+  value: T,
+): Parser<T> => {
+  return first(parser, result(value));
+};
+
+/**
+ * Tries a parser or defaults to `undefined`.
+ * @param parser The parser.
+ * @returns A parser returning the successful parse result or `undefined`.
+ *
+ * @example
+ * ```ts
+ * const number = optional(digit);
+ *
+ * number.parse("123");
+ * // [{ value: 1, remaining: "23", ... }]
+ * number.parse("abc");
+ * // [{ value: undefined, remaining: "abc", ... }]
+ */
+export const optional = <T>(parser: Parser<T>): Parser<T | undefined> => {
+  return defaulted(parser, undefined);
+};
+
+/**
  * Parses a single white space with the regex `/\s\/`
  *
  * @throws Throws "Expected a white space character" when the parse fails
@@ -303,20 +343,3 @@ export function listOf<T>(parser: Parser<T>): Parser<T[]> {
  * Parses a list of integers
  */
 export const listOfInts: Parser<number[]> = listOf(integer);
-
-/**
- * Returns the successful parse result or `null`
- */
-export const optional = <T>(parser: Parser<T>): Parser<T | null> => {
-  return first(parser, result(null));
-};
-
-/**
- * Returns the successful parse result or the default value
- */
-export const defaulted = <T>(
-  parser: Parser<T>,
-  defaultValue: T,
-): Parser<T> => {
-  return first(parser, result(defaultValue));
-};

--- a/examples/common.ts
+++ b/examples/common.ts
@@ -303,3 +303,20 @@ export function listOf<T>(parser: Parser<T>): Parser<T[]> {
  * Parses a list of integers
  */
 export const listOfInts: Parser<number[]> = listOf(integer);
+
+/**
+ * Returns the successful parse result or `null`
+ */
+export const optional = <T>(parser: Parser<T>): Parser<T | null> => {
+  return first(parser, result(null));
+};
+
+/**
+ * Returns the successful parse result or the default value
+ */
+export const defaulted = <T>(
+  parser: Parser<T>,
+  defaultValue: T,
+): Parser<T> => {
+  return first(parser, result(defaultValue));
+};

--- a/tests/common.test.ts
+++ b/tests/common.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from "@std/assert";
 import {
   decimal,
+  defaulted,
   digit,
   integer,
   letter,
@@ -8,6 +9,7 @@ import {
   literal,
   lower,
   natural,
+  optional,
   regexPredicate,
   take,
   takeTwo,
@@ -74,6 +76,64 @@ Deno.test("alternation", () => {
       value: "mo",
       remaining: "nad",
       position: { line: 1, column: 2 },
+    }],
+  });
+});
+
+Deno.test("defaulted", () => {
+  assertEquals(defaulted(digit, 42).parse("123"), {
+    success: true,
+    results: [{
+      value: 1,
+      remaining: "23",
+      position: { line: 1, column: 1 },
+    }],
+  });
+
+  assertEquals(defaulted(digit, 42).parse("abc"), {
+    success: true,
+    results: [{
+      value: 42,
+      remaining: "abc",
+      position: { line: 1, column: 0 },
+    }],
+  });
+
+  assertEquals(defaulted(digit, 42).parse(""), {
+    success: true,
+    results: [{
+      value: 42,
+      remaining: "",
+      position: { line: 1, column: 0 },
+    }],
+  });
+});
+
+Deno.test("optional", () => {
+  assertEquals(optional(digit).parse("123"), {
+    success: true,
+    results: [{
+      value: 1,
+      remaining: "23",
+      position: { line: 1, column: 1 },
+    }],
+  });
+
+  assertEquals(optional(digit).parse("abc"), {
+    success: true,
+    results: [{
+      value: undefined,
+      remaining: "abc",
+      position: { line: 1, column: 0 },
+    }],
+  });
+
+  assertEquals(optional(digit).parse(""), {
+    success: true,
+    results: [{
+      value: undefined,
+      remaining: "",
+      position: { line: 1, column: 0 },
     }],
   });
 });


### PR DESCRIPTION
Implements `optional` and `defaulted` parsers.

I'm not sure if the implementation using `first` and `result` is the right approach and if `example/common.ts` is the right place. The naming for `defaulted` to avoid the reserved keyword `default` isn't ideal and might be improved.

Also missing documentation in README and tests.

Closes #12