### PR TITLE
breaking: rename `first` to `alt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the provided base parsers and their error messages.
     - [`sequence`](#sequence)
     - [`bind`](#bind)
     - [`skip`](#skip)
-    - [`first` and `any`](#first-and-any)
+    - [`alt` and `any`](#alt-and-any)
     - [`sepBy`](#sepby)
     - [`foldL` and `foldR`](#foldl-and-foldr)
     - [`memoize` and `lazy`](#memoize-and-lazy)
@@ -258,15 +258,15 @@ const token = <T>(parser: Parser<T>) =>
 const token = <T>(parser: Parser<T>) => parser.skip(spaces);
 ```
 
-### `first` and `any`
+### `alt` and `any`
 
 When many parses are possible you can use the `any` combinator. Most of the time
 you're only interested in the first matching alternative in which case you can
-use the `first` combinator for performance – `any` always visits all branches
-while `first` returns early.
+use the `alt` combinator for performance – `any` always visits all branches
+while `alt` returns early.
 
 ```ts
-const integer = first(
+const integer = alt(
   literal("-").bind(() => natural).map((x) => -x),
   literal("+").bind(() => natural).map((x) => x),
   natural,
@@ -337,7 +337,7 @@ const mul = literal("*").map(() => (a: number, b: number) => a * b);
 
 // integer | (expr)
 const factor = memoize(() =>
-  first(
+  alt(
     integer,
     bracket(
       literal("("),
@@ -429,7 +429,7 @@ even.parseOrThrow("ab");
 ### Alternation
 
 - any: Returns all matching parses
-- first: Only returns the first successful parse result
+- alt: Only returns the first successful parse result
 
 ### Lazy evaluation
 

--- a/examples/arithmetic-expressions.ts
+++ b/examples/arithmetic-expressions.ts
@@ -4,14 +4,14 @@
  * @module
  */
 
-import { bracket, first, foldL1, foldR1, lazy, type Parser } from "../index.ts";
+import { alt, bracket, foldL1, foldR1, lazy, type Parser } from "../index.ts";
 import { literal, number } from "./common.ts";
 
-const addOp = first(
+const addOp = alt(
   literal("+").map(() => (a: number, b: number) => a + b),
   literal("-").map(() => (a: number, b: number) => a - b),
 );
-const mulOp = first(
+const mulOp = alt(
   literal("*").map(() => (a: number, b: number) => a * b),
   literal("/").map(() => (a: number, b: number) => a / b),
 );
@@ -19,7 +19,7 @@ const expOp = literal("^").map(() => (a: number, b: number) => a ** b);
 
 // decimal | integer | (expr)
 const atom = lazy(() =>
-  first(
+  alt(
     number,
     bracket(
       literal("("),

--- a/examples/common.ts
+++ b/examples/common.ts
@@ -1,8 +1,8 @@
 import { parseErrors } from "../errors.ts";
 import {
+  alt,
   bracket,
   createParser,
-  first,
   foldL1,
   many,
   type Parser,
@@ -144,7 +144,7 @@ export const defaulted = <T>(
   parser: Parser<T>,
   value: T,
 ): Parser<T> => {
-  return first(parser, result(value));
+  return alt(parser, result(value));
 };
 
 /**
@@ -306,7 +306,7 @@ export const natural: Parser<number> = foldL1(
 /**
  * Parses an integer (element of ℤ)
  */
-export const integer: Parser<number> = first(
+export const integer: Parser<number> = alt(
   literal("-").bind(() => natural).map((x) => -x),
   literal("+").bind(() => natural).map((x) => x),
   natural,
@@ -328,7 +328,7 @@ export const decimal: Parser<number> = sequence([
 /**
  * Parses a number as decimal | integer
  */
-export const number: Parser<number> = first(decimal, integer).error(
+export const number: Parser<number> = alt(decimal, integer).error(
   parseErrors.number,
 );
 

--- a/examples/csv.ts
+++ b/examples/csv.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import { bracket, first, many1, type Parser, result, sepBy } from "../index.ts";
+import { alt, bracket, many1, type Parser, result, sepBy } from "../index.ts";
 import { letters, literal, natural, newline, spaces } from "./common.ts";
 
 /**
@@ -21,7 +21,7 @@ const zip = <T, U>(array1: T[], array2: U[]): [T, U][] => {
 
 const coma = literal(",").skip(spaces);
 const string = bracket(literal('"'), letters, literal('"'));
-const item = first<string | number>(string, natural);
+const item = alt<string | number>(string, natural);
 
 /**
  * Parses a csv heading and returns the array of headers

--- a/examples/html.ts
+++ b/examples/html.ts
@@ -5,9 +5,9 @@
  */
 
 import {
+  alt,
   bracket,
   createParser,
-  first,
   many,
   type Parser,
   result,
@@ -122,7 +122,7 @@ const attributeName = regex(/^[^\s="'>\/\p{Noncharacter_Code_Point}]+/u)
   .map((name) => name.toLowerCase())
   .error("Expected a valid attribute name");
 
-const attributeValue = first(
+const attributeValue = alt(
   bracket(singleQuote, regex(/^[^']*/), singleQuote),
   bracket(doubleQuote, regex(/^[^"]*/), doubleQuote),
   regex(/^[^\s='"<>`]+/),
@@ -131,7 +131,7 @@ const attributeValue = first(
 /**
  * Parses an HTML attribute as a key, value string tuple
  */
-export const attribute: Parser<[string, string]> = first<[string, string]>(
+export const attribute: Parser<[string, string]> = alt<[string, string]>(
   sequence([
     attributeName,
     literal("=").skip(whitespaces),
@@ -245,7 +245,7 @@ export const element: Parser<MElement> = createParser((input, position) => {
  * The fragments parser
  */
 export const fragments: Parser<MFragment> = many(
-  first<MNode>(rawText, element, comment),
+  alt<MNode>(rawText, element, comment),
 );
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -380,7 +380,7 @@ export const any = <T>(...parsers: Parser<T>[]): Parser<T> => {
  * @example Signed integers
  *
  * ```ts
- * const integer = first(
+ * const integer = alt(
  *   literal("-").bind(() => natural).map((x) => -x),
  *   literal("+").bind(() => natural).map((x) => x),
  *   natural,
@@ -391,7 +391,7 @@ export const any = <T>(...parsers: Parser<T>[]): Parser<T> => {
  * integer.parse("42"); // results: [{value: 42, remaining: ''}]
  * ```
  */
-export const first = <T>(
+export const alt = <T>(
   ...parsers: Parser<T>[]
 ): Parser<T> => {
   return createParser((input, position) => {
@@ -438,7 +438,7 @@ export const iterate = <T>(parser: Parser<T>): Parser<T[]> => {
  * ```
  */
 export const many = <T>(parser: Parser<T>): Parser<T[]> => {
-  return first(
+  return alt(
     parser.bind((a) => many(parser).bind((x) => result([a, ...x]))),
     result([]),
   );
@@ -502,7 +502,7 @@ export const sepBy = <T, U>(
   parser: Parser<T>,
   sep: Parser<U>,
 ): Parser<T[]> => {
-  return first(sepBy1(parser, sep), result([]));
+  return alt(sepBy1(parser, sep), result([]));
 };
 
 /**
@@ -526,7 +526,7 @@ export const foldL1 = <T, U extends (a: T, b: T) => T>(
   operator: Parser<U>,
 ): Parser<T> => {
   const rest = (x: T): Parser<T> => {
-    return first(
+    return alt(
       operator.bind((f) => item.bind((y) => rest(f(x, y)))),
       result(x),
     );
@@ -554,7 +554,7 @@ export const foldL = <T, U extends (a: T, b: T) => T>(
   item: Parser<T>,
   operator: Parser<U>,
 ): Parser<T> => {
-  return first(foldL1(item, operator), item);
+  return alt(foldL1(item, operator), item);
 };
 
 /**
@@ -567,7 +567,7 @@ export const foldR1 = <T, U extends (a: T, b: T) => T>(
   operator: Parser<U>,
 ): Parser<T> => {
   return item.bind((x) => {
-    return first(
+    return alt(
       operator.bind((f) => foldR1(item, operator).bind((y) => result(f(x, y)))),
       result(x),
     );
@@ -595,7 +595,7 @@ export const foldR = <T, U extends (a: T, b: T) => T>(
   item: Parser<T>,
   operator: Parser<U>,
 ): Parser<T> => {
-  return first(foldR1(item, operator), item);
+  return alt(foldR1(item, operator), item);
 };
 
 // Filtering
@@ -676,7 +676,7 @@ allows us to lazily evaluate this parser definition to avoid directly referencin
  *
  * // integer | (expr)
  * const factor = lazy(() =>
- *   first(
+ *   alt(
  *     integer,
  *     bracket(
  *       literal("("),


### PR DESCRIPTION
This suggests to rename `first` to `alt`. This is a breaking change.

The term "alt" is clear, short and memorable.

This is also motivated by freeing up "first" to enable #28 which then enables #29 which in turn enables #30.

Depends on #31. Enables #28.