### PR TITLE
add `first` and `last`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the provided base parsers and their error messages.
     - [`map`](#map)
     - [`and`](#and)
     - [`bind`](#bind)
-    - [`skip`](#skip)
+    - [`first` and `last`](#first-and-last)
     - [`or` and `any`](#or-and-any)
     - [`sepBy`](#sepby)
     - [`foldL` and `foldR`](#foldl-and-foldr)
@@ -241,10 +241,11 @@ resulting value to the variable `p`, then applies the `spaces` parser, binds its
 resulting value to the unused variable `_` and as a result of the sequence
 returns `p`, effectively discarding the trailing spaces.
 
-### `skip`
+### `first` and `last`
 
-The `skip` method is a convenient shorthand when you need to skip the result of
-the next parser. We can rewrite the `token` parser from the previous section as
+The `first` combinator is a convenient way when you need to ignore the result of
+the next parser. Similarly, `last` allows you to ignore the result of the
+previous parser. We can rewrite the `token` parser from the previous section as
 follows:
 
 ```ts
@@ -255,7 +256,7 @@ const token = <T>(parser: Parser<T>) =>
   parser.bind((p) => spaces.bind((_) => result(p)));
 
 // Equivalent
-const token = <T>(parser: Parser<T>) => parser.skip(spaces);
+const token = <T>(parser: Parser<T>) => first(parser, spaces);
 ```
 
 ### `or` and `any`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ the provided base parsers and their error messages.
     - [`sequence`](#sequence)
     - [`bind`](#bind)
     - [`skip`](#skip)
-    - [`first` and `any`](#first-and-any)
+    - [`or` and `any`](#or-and-any)
     - [`sepBy`](#sepby)
     - [`foldL` and `foldR`](#foldl-and-foldr)
     - [`memoize` and `lazy`](#memoize-and-lazy)
@@ -258,15 +258,15 @@ const token = <T>(parser: Parser<T>) =>
 const token = <T>(parser: Parser<T>) => parser.skip(spaces);
 ```
 
-### `first` and `any`
+### `or` and `any`
 
 When many parses are possible you can use the `any` combinator. Most of the time
 you're only interested in the first matching alternative in which case you can
-use the `first` combinator for performance – `any` always visits all branches
-while `first` returns early.
+use the `or` combinator for performance – `any` always visits all branches while
+`or` returns early.
 
 ```ts
-const integer = first(
+const integer = or(
   literal("-").bind(() => natural).map((x) => -x),
   literal("+").bind(() => natural).map((x) => x),
   natural,
@@ -337,7 +337,7 @@ const mul = literal("*").map(() => (a: number, b: number) => a * b);
 
 // integer | (expr)
 const factor = memoize(() =>
-  first(
+  or(
     integer,
     bracket(
       literal("("),
@@ -429,7 +429,7 @@ even.parseOrThrow("ab");
 ### Alternation
 
 - any: Returns all matching parses
-- first: Only returns the first successful parse result
+- or: Only returns the first successful parse result
 
 ### Lazy evaluation
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the provided base parsers and their error messages.
     - [`regex`](#regex)
     - [`many`](#many)
     - [`map`](#map)
-    - [`sequence`](#sequence)
+    - [`and`](#and)
     - [`bind`](#bind)
     - [`skip`](#skip)
     - [`or` and `any`](#or-and-any)
@@ -191,14 +191,14 @@ const { results } = natural.parse("23 and more"); // [{value: 23, remaining: " a
 Here the returned value is a number as `digit` and `natural` have the
 `Parser<number>` type
 
-### `sequence`
+### `and`
 
 For a simple sequencing of parsers, use the
-`sequence(parsers: Parser<?>[]): Parser<?[]>` combinator. The input parsers can
-have different types, which will be reflected in the resulting parser
+`and(parsers: Parser<?>[]): Parser<?[]>` combinator. The input parsers can have
+different types, which will be reflected in the resulting parser
 
 ```ts
-const parenthesizedNumber = sequence([literal("("), natural, literal(")")]); // inferred type: Parser<[string, number, string]>
+const parenthesizedNumber = and([literal("("), natural, literal(")")]); // inferred type: Parser<[string, number, string]>
 const extract = parenthesizedNumber.map((arr) => arr[1]); // Parser<number>
 const { results } = extract.parse("(42)"); // [{value: 42, remaining: "", ...}]
 ```
@@ -404,7 +404,7 @@ even.parseOrThrow("ab");
 
 ### Sequencing
 
-- sequence: Makes a sequence of parses and returns the array of parse results
+- and: Makes a sequence of parses and returns the array of parse results
 - bracket: Utility combinator for the common open/body/close pattern
 
 ### Iteration

--- a/examples/arithmetic-expressions.ts
+++ b/examples/arithmetic-expressions.ts
@@ -4,14 +4,14 @@
  * @module
  */
 
-import { bracket, first, foldL1, foldR1, lazy, type Parser } from "../index.ts";
+import { bracket, foldL1, foldR1, lazy, or, type Parser } from "../index.ts";
 import { literal, number } from "./common.ts";
 
-const addOp = first(
+const addOp = or(
   literal("+").map(() => (a: number, b: number) => a + b),
   literal("-").map(() => (a: number, b: number) => a - b),
 );
-const mulOp = first(
+const mulOp = or(
   literal("*").map(() => (a: number, b: number) => a * b),
   literal("/").map(() => (a: number, b: number) => a / b),
 );
@@ -19,7 +19,7 @@ const expOp = literal("^").map(() => (a: number, b: number) => a ** b);
 
 // decimal | integer | (expr)
 const atom = lazy(() =>
-  first(
+  or(
     number,
     bracket(
       literal("("),

--- a/examples/common.ts
+++ b/examples/common.ts
@@ -28,9 +28,6 @@ type Predicate = (input: string) => boolean;
  * @example
  *
  * ```ts
- * import { regexPredicate, take, regex } from "./examples/common.ts";
- * import { filter } from "./index.ts";
- *
  * const isVowel = regexPredicate(/[aeiouy]/);
  * const vowel = filter(take, isVowel).error("Expected a vowel");
  * vowel.parse("allo"); // [{value: 'a', remaining: 'llo', ...}]

--- a/examples/common.ts
+++ b/examples/common.ts
@@ -1,5 +1,6 @@
 import { parseErrors } from "../errors.ts";
 import {
+  and,
   bracket,
   createParser,
   foldL1,
@@ -9,7 +10,6 @@ import {
   repeat,
   result,
   sepBy,
-  sequence,
   updatePosition,
 } from "../index.ts";
 
@@ -315,7 +315,7 @@ export const integer: Parser<number> = or(
 /**
  * Parses a decimal number aka a float
  */
-export const decimal: Parser<number> = sequence([
+export const decimal: Parser<number> = and([
   integer,
   literal("."),
   natural,

--- a/examples/common.ts
+++ b/examples/common.ts
@@ -166,6 +166,44 @@ export const optional = <T>(parser: Parser<T>): Parser<T | undefined> => {
 };
 
 /**
+ * Skips the second parser.
+ * @param parser The first parser.
+ * @param skip The second parser.
+ * @returns A parser returning the result of the first parser.
+ *
+ * @example Discard trailing spaces
+ *
+ * ```ts
+ * const word = first(letters, whitespace);
+ *
+ * word.parse("abc ");
+ * // [{ value: "abc", remaining: "", ... }]
+ * ```
+ */
+export function first<T, U>(parser: Parser<T>, skip: Parser<U>): Parser<T> {
+  return parser.bind((r) => skip.bind((_) => result(r)));
+}
+
+/**
+ * Skips the first parser.
+ * @param skip The first parser.
+ * @param parser The second parser.
+ * @returns A parser returning the result of the second parser.
+ *
+ * @example Discard leading spaces
+ *
+ * ```ts
+ * const word = last(whitespace, letters);
+ *
+ * word.parse(" abc");
+ * // [{ value: "abc", remaining: "", ... }]
+ * ```
+ */
+export function last<T, U>(skip: Parser<T>, parser: Parser<U>): Parser<U> {
+  return skip.bind((_) => parser.bind((r) => result(r)));
+}
+
+/**
  * Parses a single white space with the regex `/\s\/`
  *
  * @throws Throws "Expected a white space character" when the parse fails

--- a/examples/common.ts
+++ b/examples/common.ts
@@ -2,9 +2,9 @@ import { parseErrors } from "../errors.ts";
 import {
   bracket,
   createParser,
-  first,
   foldL1,
   many,
+  or,
   type Parser,
   repeat,
   result,
@@ -144,7 +144,7 @@ export const defaulted = <T>(
   parser: Parser<T>,
   value: T,
 ): Parser<T> => {
-  return first(parser, result(value));
+  return or(parser, result(value));
 };
 
 /**
@@ -306,7 +306,7 @@ export const natural: Parser<number> = foldL1(
 /**
  * Parses an integer (element of ℤ)
  */
-export const integer: Parser<number> = first(
+export const integer: Parser<number> = or(
   literal("-").bind(() => natural).map((x) => -x),
   literal("+").bind(() => natural).map((x) => x),
   natural,
@@ -328,7 +328,7 @@ export const decimal: Parser<number> = sequence([
 /**
  * Parses a number as decimal | integer
  */
-export const number: Parser<number> = first(decimal, integer).error(
+export const number: Parser<number> = or(decimal, integer).error(
   parseErrors.number,
 );
 

--- a/examples/csv.ts
+++ b/examples/csv.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import { bracket, first, many1, type Parser, result, sepBy } from "../index.ts";
+import { bracket, many1, or, type Parser, result, sepBy } from "../index.ts";
 import { letters, literal, natural, newline, spaces } from "./common.ts";
 
 /**
@@ -21,7 +21,7 @@ const zip = <T, U>(array1: T[], array2: U[]): [T, U][] => {
 
 const coma = literal(",").skip(spaces);
 const string = bracket(literal('"'), letters, literal('"'));
-const item = first<string | number>(string, natural);
+const item = or<string | number>(string, natural);
 
 /**
  * Parses a csv heading and returns the array of headers

--- a/examples/html.ts
+++ b/examples/html.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  and,
   bracket,
   createParser,
   many,
@@ -12,7 +13,6 @@ import {
   type Parser,
   result,
   sepBy,
-  sequence,
   zero,
 } from "@fcrozatier/monarch";
 import { literal, regex, whitespace, whitespaces } from "./common.ts";
@@ -88,7 +88,7 @@ export const comment: Parser<MCommentNode> = bracket(
 /**
  * Parses a sequence of comments maybe surrounded by whitespace
  */
-export const spacesAndComments: Parser<MSpacesAndComments> = sequence(
+export const spacesAndComments: Parser<MSpacesAndComments> = and(
   [
     whitespaceOnlyText,
     sepBy(comment, whitespaces),
@@ -101,7 +101,7 @@ export const spacesAndComments: Parser<MSpacesAndComments> = sequence(
  *
  * https://html.spec.whatwg.org/#syntax-doctype
  */
-export const doctype: Parser<MTextNode> = sequence([
+export const doctype: Parser<MTextNode> = and([
   regex(/^<!DOCTYPE/i),
   whitespace.skip(whitespaces),
   regex(/^html/i).skip(whitespaces),
@@ -132,7 +132,7 @@ const attributeValue = or(
  * Parses an HTML attribute as a key, value string tuple
  */
 export const attribute: Parser<[string, string]> = or<[string, string]>(
-  sequence([
+  and([
     attributeName,
     literal("=").skip(whitespaces),
     attributeValue,
@@ -148,7 +148,7 @@ const tagName = regex(/^[a-zA-Z][a-zA-Z0-9-]*/)
 
 const startTag: Parser<
   { tagName: string; attributes: [string, string][] }
-> = sequence([
+> = and([
   literal("<"),
   tagName,
   many(attribute),
@@ -253,7 +253,7 @@ export const fragments: Parser<MFragment> = many(
  */
 export const shadowRoot: Parser<MFragment> = createParser(
   (input, position) => {
-    const result = sequence([
+    const result = and([
       spacesAndComments,
       element,
     ]).map(([comments, element]) => [...comments, element]).parse(
@@ -293,7 +293,7 @@ export const shadowRoot: Parser<MFragment> = createParser(
  *
  * https://html.spec.whatwg.org/#writing
  */
-export const html: Parser<MFragment> = sequence([
+export const html: Parser<MFragment> = and([
   spacesAndComments,
   doctype,
   spacesAndComments,

--- a/examples/html.ts
+++ b/examples/html.ts
@@ -7,8 +7,8 @@
 import {
   bracket,
   createParser,
-  first,
   many,
+  or,
   type Parser,
   result,
   sepBy,
@@ -122,7 +122,7 @@ const attributeName = regex(/^[^\s="'>\/\p{Noncharacter_Code_Point}]+/u)
   .map((name) => name.toLowerCase())
   .error("Expected a valid attribute name");
 
-const attributeValue = first(
+const attributeValue = or(
   bracket(singleQuote, regex(/^[^']*/), singleQuote),
   bracket(doubleQuote, regex(/^[^"]*/), doubleQuote),
   regex(/^[^\s='"<>`]+/),
@@ -131,7 +131,7 @@ const attributeValue = first(
 /**
  * Parses an HTML attribute as a key, value string tuple
  */
-export const attribute: Parser<[string, string]> = first<[string, string]>(
+export const attribute: Parser<[string, string]> = or<[string, string]>(
   sequence([
     attributeName,
     literal("=").skip(whitespaces),
@@ -245,7 +245,7 @@ export const element: Parser<MElement> = createParser((input, position) => {
  * The fragments parser
  */
 export const fragments: Parser<MFragment> = many(
-  first<MNode>(rawText, element, comment),
+  or<MNode>(rawText, element, comment),
 );
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -380,7 +380,7 @@ export const any = <T>(...parsers: Parser<T>[]): Parser<T> => {
  * @example Signed integers
  *
  * ```ts
- * const integer = first(
+ * const integer = or(
  *   literal("-").bind(() => natural).map((x) => -x),
  *   literal("+").bind(() => natural).map((x) => x),
  *   natural,
@@ -391,7 +391,7 @@ export const any = <T>(...parsers: Parser<T>[]): Parser<T> => {
  * integer.parse("42"); // results: [{value: 42, remaining: ''}]
  * ```
  */
-export const first = <T>(
+export const or = <T>(
   ...parsers: Parser<T>[]
 ): Parser<T> => {
   return createParser((input, position) => {
@@ -438,7 +438,7 @@ export const iterate = <T>(parser: Parser<T>): Parser<T[]> => {
  * ```
  */
 export const many = <T>(parser: Parser<T>): Parser<T[]> => {
-  return first(
+  return or(
     parser.bind((a) => many(parser).bind((x) => result([a, ...x]))),
     result([]),
   );
@@ -502,7 +502,7 @@ export const sepBy = <T, U>(
   parser: Parser<T>,
   sep: Parser<U>,
 ): Parser<T[]> => {
-  return first(sepBy1(parser, sep), result([]));
+  return or(sepBy1(parser, sep), result([]));
 };
 
 /**
@@ -526,7 +526,7 @@ export const foldL1 = <T, U extends (a: T, b: T) => T>(
   operator: Parser<U>,
 ): Parser<T> => {
   const rest = (x: T): Parser<T> => {
-    return first(
+    return or(
       operator.bind((f) => item.bind((y) => rest(f(x, y)))),
       result(x),
     );
@@ -554,7 +554,7 @@ export const foldL = <T, U extends (a: T, b: T) => T>(
   item: Parser<T>,
   operator: Parser<U>,
 ): Parser<T> => {
-  return first(foldL1(item, operator), item);
+  return or(foldL1(item, operator), item);
 };
 
 /**
@@ -567,7 +567,7 @@ export const foldR1 = <T, U extends (a: T, b: T) => T>(
   operator: Parser<U>,
 ): Parser<T> => {
   return item.bind((x) => {
-    return first(
+    return or(
       operator.bind((f) => foldR1(item, operator).bind((y) => result(f(x, y)))),
       result(x),
     );
@@ -595,7 +595,7 @@ export const foldR = <T, U extends (a: T, b: T) => T>(
   item: Parser<T>,
   operator: Parser<U>,
 ): Parser<T> => {
-  return first(foldR1(item, operator), item);
+  return or(foldR1(item, operator), item);
 };
 
 // Filtering
@@ -676,7 +676,7 @@ allows us to lazily evaluate this parser definition to avoid directly referencin
  *
  * // integer | (expr)
  * const factor = lazy(() =>
- *   first(
+ *   or(
  *     integer,
  *     bracket(
  *       literal("("),

--- a/index.ts
+++ b/index.ts
@@ -298,7 +298,7 @@ type Unpack<T> = {
  * @example Reimplementing the `bracket` parser
  *
  * ```ts
- * const parenthesizedNumber = sequence([literal("("), natural, literal(")")]);
+ * const parenthesizedNumber = and([literal("("), natural, literal(")")]);
  * // inferred type: Parser<[string, number, string]>
  *
  * const extract: Parser<number> = parenthesizedNumber.map((arr) => arr[1]);
@@ -308,14 +308,14 @@ type Unpack<T> = {
  *
  * @see {@linkcode bracket}
  */
-export const sequence = <const A extends readonly Parser<unknown>[]>(
+export const and = <const A extends readonly Parser<unknown>[]>(
   parsers: A,
   acc = [] as Unpack<A>,
 ): Parser<Unpack<A>> => {
   if (parsers.length > 0) {
     // @ts-ignore existential types
     return parsers[0].bind((x) => {
-      return sequence(parsers.slice(1), [...acc, x]);
+      return and(parsers.slice(1), [...acc, x]);
     }).bind((arr) => result(arr));
   }
   return result(acc);
@@ -341,9 +341,7 @@ export function bracket<T, U, V>(
   body: Parser<U>,
   closeBracket: Parser<V>,
 ): Parser<U> {
-  return sequence([openBracket, body, closeBracket]).bind((arr) =>
-    result(arr[1])
-  );
+  return and([openBracket, body, closeBracket]).bind((arr) => result(arr[1]));
 }
 
 // Alternation

--- a/tests/common.test.ts
+++ b/tests/common.test.ts
@@ -3,7 +3,9 @@ import {
   decimal,
   defaulted,
   digit,
+  first,
   integer,
+  last,
   letter,
   listOfInts,
   literal,
@@ -135,6 +137,52 @@ Deno.test("optional", () => {
       remaining: "",
       position: { line: 1, column: 0 },
     }],
+  });
+});
+
+Deno.test("first", () => {
+  assertEquals(first(digit, letter).parse("1a"), {
+    success: true,
+    results: [{
+      value: 1,
+      remaining: "",
+      position: { line: 1, column: 2 },
+    }],
+  });
+
+  assertEquals(first(digit, letter).parse("12"), {
+    success: false,
+    message: parseErrors.letter,
+    position: { line: 1, column: 1 },
+  });
+
+  assertEquals(first(digit, letter).parse("ab"), {
+    success: false,
+    message: parseErrors.digit,
+    position: { line: 1, column: 0 },
+  });
+});
+
+Deno.test("last", () => {
+  assertEquals(last(digit, letter).parse("1a"), {
+    success: true,
+    results: [{
+      value: "a",
+      remaining: "",
+      position: { line: 1, column: 2 },
+    }],
+  });
+
+  assertEquals(last(digit, letter).parse("12"), {
+    success: false,
+    message: parseErrors.letter,
+    position: { line: 1, column: 1 },
+  });
+
+  assertEquals(last(digit, letter).parse("ab"), {
+    success: false,
+    message: parseErrors.digit,
+    position: { line: 1, column: 0 },
   });
 });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -63,7 +63,9 @@ Deno.test("many", () => {
       position: { line: 1, column: 0 },
     }],
   });
+});
 
+Deno.test("many1", () => {
   // Matches 1 or more times
   assertEquals(many1(digit).error("Expected many digits").parse("a"), {
     success: false,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -8,7 +8,7 @@ import {
   take,
   takeTwo,
 } from "../examples/common.ts";
-import { any, iterate, many, many1, result, sequence, zero } from "../index.ts";
+import { and, any, iterate, many, many1, result, zero } from "../index.ts";
 
 Deno.test("zero is an absorbing element of bind", () => {
   assertEquals(zero.bind(() => take).parse("m"), zero.parse("m"));
@@ -74,9 +74,9 @@ Deno.test("many1", () => {
   });
 });
 
-Deno.test("sequence", () => {
+Deno.test("and", () => {
   assertEquals(
-    sequence([literal("a"), digit]).bind(([str, num]) =>
+    and([literal("a"), digit]).bind(([str, num]) =>
       result(str.toUpperCase() + `${num * 100}`)
     ).parse("a3"),
     {
@@ -123,7 +123,7 @@ Deno.test("explore", () => {
   });
 });
 
-const thrw = sequence([number, literal("then"), number]);
+const thrw = and([number, literal("then"), number]);
 
 Deno.test("parse error", () => {
   assertEquals(take.parseOrThrow("monad"), "m");


### PR DESCRIPTION
This adds new `first` and `last` sequencing combinators to skip the last or first parser. The `first` function is an alternative to the `.skip()` method that can be composed rather than chained.

The names "first" and "last" are symmetric and seem descriptive. Alternatives could be "left" and "right" which might sound directional, "start" and "end" which might refer to the input as a whole, "prefix" and "suffix" which might sound technical.

Depends on #27. Enables #29.