### PR TITLE
add `first` and `last`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the provided base parsers and their error messages.
     - [`map`](#map)
     - [`sequence`](#sequence)
     - [`bind`](#bind)
-    - [`skip`](#skip)
+    - [`first` and `last`](#first-and-last)
     - [`alt` and `any`](#alt-and-any)
     - [`sepBy`](#sepby)
     - [`foldL` and `foldR`](#foldl-and-foldr)
@@ -241,10 +241,11 @@ resulting value to the variable `p`, then applies the `spaces` parser, binds its
 resulting value to the unused variable `_` and as a result of the sequence
 returns `p`, effectively discarding the trailing spaces.
 
-### `skip`
+### `first` and `last`
 
-The `skip` method is a convenient shorthand when you need to skip the result of
-the next parser. We can rewrite the `token` parser from the previous section as
+The `first` combinator is a convenient way when you need to ignore the result of
+the next parser. Similarly, `last` allows you to ignore the result of the
+previous parser. We can rewrite the `token` parser from the previous section as
 follows:
 
 ```ts
@@ -255,7 +256,7 @@ const token = <T>(parser: Parser<T>) =>
   parser.bind((p) => spaces.bind((_) => result(p)));
 
 // Equivalent
-const token = <T>(parser: Parser<T>) => parser.skip(spaces);
+const token = <T>(parser: Parser<T>) => first(parser, spaces);
 ```
 
 ### `alt` and `any`

--- a/examples/common.ts
+++ b/examples/common.ts
@@ -166,6 +166,46 @@ export const optional = <T>(parser: Parser<T>): Parser<T | undefined> => {
 };
 
 /**
+ * Skips the second parser
+ *
+ * @param parser The first parser
+ * @param skip The second parser
+ * @returns A parser returning the result of the first parser
+ *
+ * @example Discard trailing spaces
+ *
+ * ```ts
+ * const word = first(letters, whitespace);
+ *
+ * word.parse("abc ");
+ * // [{ value: "abc", remaining: "", ... }]
+ * ```
+ */
+export function first<T, U>(parser: Parser<T>, skip: Parser<U>): Parser<T> {
+  return parser.bind((r) => skip.bind((_) => result(r)));
+}
+
+/**
+ * Skips the first parser
+ *
+ * @param skip The first parser
+ * @param parser The second parser
+ * @returns A parser returning the result of the second parser
+ *
+ * @example Discard leading spaces
+ *
+ * ```ts
+ * const word = last(whitespace, letters);
+ *
+ * word.parse(" abc");
+ * // [{ value: "abc", remaining: "", ... }]
+ * ```
+ */
+export function last<T, U>(skip: Parser<T>, parser: Parser<U>): Parser<U> {
+  return skip.bind((_) => parser.bind((r) => result(r)));
+}
+
+/**
  * Parses a single white space with the regex `/\s\/`
  *
  * @throws Throws "Expected a white space character" when the parse fails

--- a/tests/common.test.ts
+++ b/tests/common.test.ts
@@ -3,7 +3,9 @@ import {
   decimal,
   defaulted,
   digit,
+  first,
   integer,
+  last,
   letter,
   listOfInts,
   literal,
@@ -135,6 +137,52 @@ Deno.test("optional", () => {
       remaining: "",
       position: { line: 1, column: 0 },
     }],
+  });
+});
+
+Deno.test("first", () => {
+  assertEquals(first(digit, letter).parse("1a"), {
+    success: true,
+    results: [{
+      value: 1,
+      remaining: "",
+      position: { line: 1, column: 2 },
+    }],
+  });
+
+  assertEquals(first(digit, letter).parse("12"), {
+    success: false,
+    message: parseErrors.letter,
+    position: { line: 1, column: 1 },
+  });
+
+  assertEquals(first(digit, letter).parse("ab"), {
+    success: false,
+    message: parseErrors.digit,
+    position: { line: 1, column: 0 },
+  });
+});
+
+Deno.test("last", () => {
+  assertEquals(last(digit, letter).parse("1a"), {
+    success: true,
+    results: [{
+      value: "a",
+      remaining: "",
+      position: { line: 1, column: 2 },
+    }],
+  });
+
+  assertEquals(last(digit, letter).parse("12"), {
+    success: false,
+    message: parseErrors.letter,
+    position: { line: 1, column: 1 },
+  });
+
+  assertEquals(last(digit, letter).parse("ab"), {
+    success: false,
+    message: parseErrors.digit,
+    position: { line: 1, column: 0 },
   });
 });
 


### PR DESCRIPTION
This adds new `first` and `last` sequencing combinators to skip the last or first parser. The `first` function is an alternative to the `.skip()` method that can be composed rather than chained.

The names "first" and "last" are symmetric and seem descriptive. Alternatives could be "left" and "right" which might sound directional, "start" and "end" which might refer to the input as a whole, "prefix" and "suffix" which might sound technical.

Depends on #27. Enables #29.
(Reopened #28)