### PR TITLE
breaking: variadic `seq`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the provided base parsers and their error messages.
     - [`regex`](#regex)
     - [`many`](#many)
     - [`map`](#map)
-    - [`sequence`](#sequence)
+    - [`seq`](#seq)
     - [`bind`](#bind)
     - [`skip`](#skip)
     - [`alt` and `any`](#alt-and-any)
@@ -191,14 +191,14 @@ const { results } = natural.parse("23 and more"); // [{value: 23, remaining: " a
 Here the returned value is a number as `digit` and `natural` have the
 `Parser<number>` type
 
-### `sequence`
+### `seq`
 
 For a simple sequencing of parsers, use the
-`sequence(parsers: Parser<?>[]): Parser<?[]>` combinator. The input parsers can
-have different types, which will be reflected in the resulting parser
+`seq(parsers: Parser<?>[]): Parser<?[]>` combinator. The input parsers can have
+different types, which will be reflected in the resulting parser
 
 ```ts
-const parenthesizedNumber = sequence([literal("("), natural, literal(")")]); // inferred type: Parser<[string, number, string]>
+const parenthesizedNumber = seq([literal("("), natural, literal(")")]); // inferred type: Parser<[string, number, string]>
 const extract = parenthesizedNumber.map((arr) => arr[1]); // Parser<number>
 const { results } = extract.parse("(42)"); // [{value: 42, remaining: "", ...}]
 ```
@@ -404,7 +404,7 @@ even.parseOrThrow("ab");
 
 ### Sequencing
 
-- sequence: Makes a sequence of parses and returns the array of parse results
+- seq: Makes a sequence of parses and returns the array of parse results
 - between: Utility combinator for the common open/body/close pattern
 
 ### Iteration

--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ For a simple sequencing of parsers, use the
 different types, which will be reflected in the resulting parser
 
 ```ts
-const parenthesizedNumber = seq([literal("("), natural, literal(")")]); // inferred type: Parser<[string, number, string]>
+const parenthesizedNumber = seq(literal("("), natural, literal(")")); // inferred type: Parser<[string, number, string]>
 const extract = parenthesizedNumber.map((arr) => arr[1]); // Parser<number>
-const { results } = extract.parse("(42)"); // [{value: 42, remaining: "", ...}]
+extract.parseOrThrow("(42)"); // 42
 ```
 
 ### `bind`

--- a/examples/common.ts
+++ b/examples/common.ts
@@ -9,7 +9,7 @@ import {
   repeat,
   result,
   sepBy,
-  sequence,
+  seq,
   updatePosition,
 } from "../index.ts";
 
@@ -315,7 +315,7 @@ export const integer: Parser<number> = alt(
 /**
  * Parses a decimal number aka a float
  */
-export const decimal: Parser<number> = sequence([
+export const decimal: Parser<number> = seq([
   integer,
   literal("."),
   natural,

--- a/examples/common.ts
+++ b/examples/common.ts
@@ -315,11 +315,11 @@ export const integer: Parser<number> = alt(
 /**
  * Parses a decimal number aka a float
  */
-export const decimal: Parser<number> = seq([
+export const decimal: Parser<number> = seq(
   integer,
   literal("."),
   natural,
-]).map(([integral, _, fractional]) =>
+).map(([integral, _, fractional]) =>
   integral +
   Math.sign(integral) * Math.pow(10, -Math.ceil(Math.log10(fractional))) *
     fractional

--- a/examples/html.ts
+++ b/examples/html.ts
@@ -89,11 +89,9 @@ export const comment: Parser<MCommentNode> = between(
  * Parses a sequence of comments maybe surrounded by whitespace
  */
 export const spacesAndComments: Parser<MSpacesAndComments> = seq(
-  [
-    whitespaceOnlyText,
-    sepBy(comment, whitespaces),
-    whitespaceOnlyText,
-  ],
+  whitespaceOnlyText,
+  sepBy(comment, whitespaces),
+  whitespaceOnlyText,
 ).map(([space1, comments, space2]) => [space1, ...comments, space2]);
 
 /**
@@ -101,12 +99,12 @@ export const spacesAndComments: Parser<MSpacesAndComments> = seq(
  *
  * https://html.spec.whatwg.org/#syntax-doctype
  */
-export const doctype: Parser<MTextNode> = seq([
+export const doctype: Parser<MTextNode> = seq(
   regex(/^<!DOCTYPE/i),
   whitespace.skip(whitespaces),
   regex(/^html/i).skip(whitespaces),
   literal(">"),
-]).map(() => textNode("<!DOCTYPE html>")).error("Expected a valid doctype");
+).map(() => textNode("<!DOCTYPE html>")).error("Expected a valid doctype");
 
 const singleQuote = literal("'");
 const doubleQuote = literal('"');
@@ -132,11 +130,11 @@ const attributeValue = alt(
  * Parses an HTML attribute as a key, value string tuple
  */
 export const attribute: Parser<[string, string]> = alt<[string, string]>(
-  seq([
+  seq(
     attributeName,
     literal("=").skip(whitespaces),
     attributeValue,
-  ]).map(([name, _, value]) => [name, value]),
+  ).map(([name, _, value]) => [name, value]),
   attributeName.map((name) => [name, ""]),
 ).skip(whitespaces);
 
@@ -148,12 +146,12 @@ const tagName = regex(/^[a-zA-Z][a-zA-Z0-9-]*/)
 
 const startTag: Parser<
   { tagName: string; attributes: [string, string][] }
-> = seq([
+> = seq(
   literal("<"),
   tagName,
   many(attribute),
   regex(/\/?>/),
-]).error("Expected a start tag").bind(([_, tagName, attributes, end]) => {
+).error("Expected a start tag").bind(([_, tagName, attributes, end]) => {
   const selfClosing = end === "/>";
   if (selfClosing && !voidElements.includes(tagName)) {
     return zero.error("Unexpected self-closing tag on a non-void element");
@@ -253,10 +251,10 @@ export const fragments: Parser<MFragment> = many(
  */
 export const shadowRoot: Parser<MFragment> = createParser(
   (input, position) => {
-    const result = seq([
+    const result = seq(
       spacesAndComments,
       element,
-    ]).map(([comments, element]) => [...comments, element]).parse(
+    ).map(([comments, element]) => [...comments, element]).parse(
       input,
       position,
     );
@@ -293,13 +291,13 @@ export const shadowRoot: Parser<MFragment> = createParser(
  *
  * https://html.spec.whatwg.org/#writing
  */
-export const html: Parser<MFragment> = seq([
+export const html: Parser<MFragment> = seq(
   spacesAndComments,
   doctype,
   spacesAndComments,
   element,
   spacesAndComments,
-]).map((fragments) => fragments.flat());
+).map((fragments) => fragments.flat());
 
 /**
  * The monarch serialization options

--- a/examples/html.ts
+++ b/examples/html.ts
@@ -12,7 +12,7 @@ import {
   type Parser,
   result,
   sepBy,
-  sequence,
+  seq,
   zero,
 } from "@fcrozatier/monarch";
 import { literal, regex, whitespace, whitespaces } from "./common.ts";
@@ -88,7 +88,7 @@ export const comment: Parser<MCommentNode> = between(
 /**
  * Parses a sequence of comments maybe surrounded by whitespace
  */
-export const spacesAndComments: Parser<MSpacesAndComments> = sequence(
+export const spacesAndComments: Parser<MSpacesAndComments> = seq(
   [
     whitespaceOnlyText,
     sepBy(comment, whitespaces),
@@ -101,7 +101,7 @@ export const spacesAndComments: Parser<MSpacesAndComments> = sequence(
  *
  * https://html.spec.whatwg.org/#syntax-doctype
  */
-export const doctype: Parser<MTextNode> = sequence([
+export const doctype: Parser<MTextNode> = seq([
   regex(/^<!DOCTYPE/i),
   whitespace.skip(whitespaces),
   regex(/^html/i).skip(whitespaces),
@@ -132,7 +132,7 @@ const attributeValue = alt(
  * Parses an HTML attribute as a key, value string tuple
  */
 export const attribute: Parser<[string, string]> = alt<[string, string]>(
-  sequence([
+  seq([
     attributeName,
     literal("=").skip(whitespaces),
     attributeValue,
@@ -148,7 +148,7 @@ const tagName = regex(/^[a-zA-Z][a-zA-Z0-9-]*/)
 
 const startTag: Parser<
   { tagName: string; attributes: [string, string][] }
-> = sequence([
+> = seq([
   literal("<"),
   tagName,
   many(attribute),
@@ -253,7 +253,7 @@ export const fragments: Parser<MFragment> = many(
  */
 export const shadowRoot: Parser<MFragment> = createParser(
   (input, position) => {
-    const result = sequence([
+    const result = seq([
       spacesAndComments,
       element,
     ]).map(([comments, element]) => [...comments, element]).parse(
@@ -293,7 +293,7 @@ export const shadowRoot: Parser<MFragment> = createParser(
  *
  * https://html.spec.whatwg.org/#writing
  */
-export const html: Parser<MFragment> = sequence([
+export const html: Parser<MFragment> = seq([
   spacesAndComments,
   doctype,
   spacesAndComments,

--- a/index.ts
+++ b/index.ts
@@ -293,12 +293,14 @@ type Unpack<T> = {
 /**
  * Makes a sequence of parses and returns the array of parse results
  *
+ * Succeeds if all parsers in the sequence are successful.
+ *
  * The input parsers can be of different types
  *
  * @example Reimplementing the `between` parser
  *
  * ```ts
- * const parenthesizedNumber = sequence([literal("("), natural, literal(")")]);
+ * const parenthesizedNumber = seq([literal("("), natural, literal(")")]);
  * // inferred type: Parser<[string, number, string]>
  *
  * const extract: Parser<number> = parenthesizedNumber.map((arr) => arr[1]);
@@ -308,14 +310,14 @@ type Unpack<T> = {
  *
  * @see {@linkcode between}
  */
-export const sequence = <const A extends readonly Parser<unknown>[]>(
+export const seq = <const A extends readonly Parser<unknown>[]>(
   parsers: A,
   acc = [] as Unpack<A>,
 ): Parser<Unpack<A>> => {
   if (parsers.length > 0) {
     // @ts-ignore existential types
     return parsers[0].bind((x) => {
-      return sequence(parsers.slice(1), [...acc, x]);
+      return seq(parsers.slice(1), [...acc, x]);
     }).bind((arr) => result(arr));
   }
   return result(acc);
@@ -362,7 +364,7 @@ export function between<T, U, V>(
   body: Parser<U>,
   close: Parser<V>,
 ): Parser<U> {
-  return sequence([open, body, close]).bind((arr) => result(arr[1]));
+  return seq([open, body, close]).bind((arr) => result(arr[1]));
 }
 
 // Alternation

--- a/index.ts
+++ b/index.ts
@@ -284,43 +284,43 @@ export const zero: Parser<never> = createParser((_, position) => ({
 // Sequencing
 
 /**
- * Unpacks an array of parsers types
+ * Maps an heterogeneous array of Parser types to their inner types
+ *
+ * @internal
  */
-type Unpack<T> = {
-  [K in keyof T]: T[K] extends Parser<infer A> ? A : never;
+type Unwrap<T extends Parser<unknown>[]> = {
+  [K in keyof T]: T[K] extends Parser<infer U> ? U : never;
 };
 
 /**
- * Makes a sequence of parses and returns the array of parse results
+ * The sequence combinator
  *
- * Succeeds if all parsers in the sequence are successful.
+ * Succeeds if all parsers of the sequence are successful.
  *
  * The input parsers can be of different types
  *
  * @example Reimplementing the `between` parser
  *
  * ```ts
- * const parenthesizedNumber = seq([literal("("), natural, literal(")")]);
+ * const parenthesizedNumber = seq(literal("("), natural, literal(")"));
  * // inferred type: Parser<[string, number, string]>
  *
- * const extract: Parser<number> = parenthesizedNumber.map((arr) => arr[1]);
- * const { results } = extract.parse("(42)");
- * // [{value: 42, remaining: "", ...}]
+ * const extract = parenthesizedNumber.map((arr) => arr[1]);
+ * extract.parseOrThrow("(42)"); // 42
  * ```
+ *
+ * @param parsers The parsers
  *
  * @see {@linkcode between}
  */
-export const seq = <const A extends readonly Parser<unknown>[]>(
-  parsers: A,
-  acc = [] as Unpack<A>,
-): Parser<Unpack<A>> => {
-  if (parsers.length > 0) {
-    // @ts-ignore existential types
-    return parsers[0].bind((x) => {
-      return seq(parsers.slice(1), [...acc, x]);
-    }).bind((arr) => result(arr));
-  }
-  return result(acc);
+export const seq = <T extends Parser<unknown>[]>(
+  ...parsers: T
+): Parser<Unwrap<T>> => {
+  return parsers.reduceRight(
+    (acc: Parser<Unwrap<T>>, parser) =>
+      parser.bind((r) => acc.map((rest) => [r, ...rest] as Unwrap<T>)),
+    result([] as Unwrap<T>),
+  );
 };
 
 /**
@@ -364,7 +364,7 @@ export function between<T, U, V>(
   body: Parser<U>,
   close: Parser<V>,
 ): Parser<U> {
-  return seq([open, body, close]).bind((arr) => result(arr[1]));
+  return seq(open, body, close).bind((arr) => result(arr[1]));
 }
 
 // Alternation

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -76,7 +76,7 @@ Deno.test("many1", () => {
 
 Deno.test("sequence", () => {
   assertEquals(
-    seq([literal("a"), digit]).bind(([str, num]) =>
+    seq(literal("a"), digit).bind(([str, num]) =>
       result(str.toUpperCase() + `${num * 100}`)
     ).parse("a3"),
     {
@@ -123,7 +123,7 @@ Deno.test("explore", () => {
   });
 });
 
-const thrw = seq([number, literal("then"), number]);
+const thrw = seq(number, literal("then"), number);
 
 Deno.test("parse error", () => {
   assertEquals(take.parseOrThrow("monad"), "m");

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -8,7 +8,7 @@ import {
   take,
   takeTwo,
 } from "../examples/common.ts";
-import { any, iterate, many, many1, result, sequence, zero } from "../index.ts";
+import { any, iterate, many, many1, result, seq, zero } from "../index.ts";
 
 Deno.test("zero is an absorbing element of bind", () => {
   assertEquals(zero.bind(() => take).parse("m"), zero.parse("m"));
@@ -76,7 +76,7 @@ Deno.test("many1", () => {
 
 Deno.test("sequence", () => {
   assertEquals(
-    sequence([literal("a"), digit]).bind(([str, num]) =>
+    seq([literal("a"), digit]).bind(([str, num]) =>
       result(str.toUpperCase() + `${num * 100}`)
     ).parse("a3"),
     {
@@ -123,7 +123,7 @@ Deno.test("explore", () => {
   });
 });
 
-const thrw = sequence([number, literal("then"), number]);
+const thrw = seq([number, literal("then"), number]);
 
 Deno.test("parse error", () => {
   assertEquals(take.parseOrThrow("monad"), "m");


### PR DESCRIPTION
Renames the `sequence` parser to `seq`, in par with its dual `alt`, and `sep*`

Also this makes it variadic

