### PR TITLE
breaking: remove plus

### DIFF
--- a/src/combinators/alternation/any.ts
+++ b/src/combinators/alternation/any.ts
@@ -62,6 +62,7 @@ export const any = <T>(...parsers: Parser<T>[]): Parser<T> => {
     const results = parsers.map((parser) => parser.parse(input, position));
 
     if (results.every((r) => r.success === false)) {
+      // Heuristic: return the error message of the most successful parse
       const [error] = results.sort((a, b) =>
         sortPosition(a.position, b.position)
       );

--- a/src/combinators/iteration/iterate.ts
+++ b/src/combinators/iteration/iterate.ts
@@ -1,5 +1,6 @@
 import type { Parser } from "$core";
 import { result } from "$core";
+import { any } from "$combinators";
 
 /**
  * Returns an array of all iterated parses
@@ -12,6 +13,8 @@ import { result } from "$core";
  * ```
  */
 export const iterate = <T>(parser: Parser<T>): Parser<T[]> => {
-  return parser.bind((a) => iterate(parser).bind((x) => result([a, ...x])))
-    .plus(result([]));
+  return any(
+    parser.bind((a) => iterate(parser).bind((x) => result([a, ...x]))),
+    result([]),
+  );
 };

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -281,32 +281,6 @@ export class Parser<T> {
   }
 
   /**
-   * Concatenates the resulting parse arrays
-   */
-  plus(...parsers: Parser<T>[]): Parser<T> {
-    return createParser((input, position) => {
-      const results = [this, ...parsers].map((parser) =>
-        parser.#parse(input, position)
-      );
-
-      if (results.every((r) => r.success === false)) {
-        // Heuristic: return the error message of the most successful parse
-        const [error] = results.sort((a, b) =>
-          sortPosition(a.position, b.position)
-        );
-
-        return error;
-      }
-      return {
-        success: true,
-        results: results.filter((r) => r.success === true).flatMap((r) =>
-          r.results
-        ),
-      };
-    });
-  }
-
-  /**
    * Customize the error message of a parser
    *
    * @example

--- a/src/core/zero.ts
+++ b/src/core/zero.ts
@@ -3,7 +3,7 @@ import { createParser, type Parser } from "./parser.ts";
 /**
  * The always failing parser
  *
- * It is the unit of alternation and plus, and also is an absorbing element of bind
+ * It is the unit of alternation, and an absorbing element of bind
  */
 export const zero: Parser<never> = createParser((_, position) => ({
   success: false,


### PR DESCRIPTION
The `plus` method is redundant with the `any` combinator