### PR TITLE
breaking: rename `take` to `anyChar`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ the provided base parsers and their error messages.
   - [Installation](#installation)
   - [Examples](#examples)
   - [Getting Started Guide](#getting-started-guide)
-    - [`take`](#take)
+    - [`anyChar`](#anyChar)
     - [`repeat`](#repeat)
     - [`literal`](#literal)
     - [`filter`](#filter)
@@ -101,15 +101,15 @@ section for more.
 Here's a progressive introduction to the various available base parsers and
 combinators of the library.
 
-### `take`
+### `anyChar`
 
-The `take` parser consumes the next character of the input
+The `anyChar` parser consumes the next character of the input
 
 ```js
-const { results } = take.parse("hello"); // [{value: 'h', remaining: 'ello', ...}]
+const { results } = anyChar.parse("hello"); // [{value: 'h', remaining: 'ello', ...}]
 ```
 
-The return value is a string as `take` is a `Parser<string>`
+The return value is a string as `anyChar` is a `Parser<string>`
 
 ### `repeat`
 
@@ -117,7 +117,7 @@ To apply a given parser a specific amount of times you can wrap it with the
 `repeat<T>(parser: Parser<T>, times: number): Parser<T>` combinator
 
 ```js
-const { results } = repeat(take, 2).parse("hello"); // [{value: 'he', remaining: 'llo', ...}]
+const { results } = repeat(anyChar, 2).parse("hello"); // [{value: 'he', remaining: 'llo', ...}]
 ```
 
 ### `literal`
@@ -139,7 +139,7 @@ parser. A filtered parser only matches when the predicate is satisfied.
 
 ```js
 const isVowel = (char) => ["a", "e", "i", "o", "u", "y"].includes(char);
-const vowel = filter(take, isVowel).error("Expected a vowel");
+const vowel = filter(anyChar, isVowel).error("Expected a vowel");
 const { results } = vowel.parse("a"); // [{value: '2', remaining: '', ...}]
 const { message } = vowel.parse("1"); // "Expected a vowel"
 ```

--- a/src/combinators/alternation/explore.test.ts
+++ b/src/combinators/alternation/explore.test.ts
@@ -1,11 +1,13 @@
 import { many, repeat } from "$combinators";
-import { literal, anyChar } from "$common";
+import { anyChar, literal } from "$common";
 import { assertEquals } from "@std/assert";
 import { parseErrors } from "../../errors.ts";
 import { explore } from "./explore.ts";
 
 const takeTwoError = "Expected two characters";
-const takeTwo = repeat(anyChar, 2).map((arr) => arr.join("")).error(takeTwoError);
+const takeTwo = repeat(anyChar, 2).map((arr) => arr.join("")).error(
+  takeTwoError,
+);
 const oneOrTwoChars = explore(anyChar, takeTwo);
 
 Deno.test("take two", () => {

--- a/src/combinators/alternation/explore.test.ts
+++ b/src/combinators/alternation/explore.test.ts
@@ -1,12 +1,12 @@
 import { many, repeat } from "$combinators";
-import { literal, take } from "$common";
+import { literal, anyChar } from "$common";
 import { assertEquals } from "@std/assert";
 import { parseErrors } from "../../errors.ts";
 import { explore } from "./explore.ts";
 
 const takeTwoError = "Expected two characters";
-const takeTwo = repeat(take, 2).map((arr) => arr.join("")).error(takeTwoError);
-const oneOrTwoChars = explore(take, takeTwo);
+const takeTwo = repeat(anyChar, 2).map((arr) => arr.join("")).error(takeTwoError);
+const oneOrTwoChars = explore(anyChar, takeTwo);
 
 Deno.test("take two", () => {
   assertEquals(takeTwo.parse("m"), {

--- a/src/combinators/alternation/explore.ts
+++ b/src/combinators/alternation/explore.ts
@@ -7,7 +7,7 @@ import { sortPosition } from "../../utils.ts";
  * @example Parse one or two characters
  *
  * ```ts
- * const oneOrTwoChars = explore(take, takeTwo);
+ * const oneOrTwoChars = explore(anyChar, repeat(anyChar, 2));
  *
  * assertEquals(oneOrTwoChars.parse("monad"), {
  *   success: true,

--- a/src/combinators/iteration/repeat.ts
+++ b/src/combinators/iteration/repeat.ts
@@ -4,10 +4,10 @@ import { result } from "$core";
 /**
  * Repeats a parser a predefined number of times
  *
- * @example Repeated {@linkcode take}
+ * @example Repeated {@linkcode anyChar}
  *
  * ```ts
- * const { results } = repeat(take, 2).parse("hello"); // [{value: 'he', remaining: 'llo', ...}]
+ * const { results } = repeat(anyChar, 2).parse("hello"); // [{value: 'he', remaining: 'llo', ...}]
  * ```
  */
 export const repeat = <T>(parser: Parser<T>, times: number): Parser<T[]> => {

--- a/src/common/characters.test.ts
+++ b/src/common/characters.test.ts
@@ -1,15 +1,15 @@
-import { letter, lower, take, upper } from "$common";
+import { letter, lower, anyChar, upper } from "$common";
 import { parseErrors } from "../errors.ts";
 import { assertEquals } from "@std/assert";
 
-Deno.test("take", () => {
-  assertEquals(take.parse(""), {
+Deno.test("anyChar", () => {
+  assertEquals(anyChar.parse(""), {
     success: false,
     message: parseErrors.takeError,
     position: { line: 1, column: 0 },
   });
 
-  assertEquals(take.parse("monad"), {
+  assertEquals(anyChar.parse("monad"), {
     success: true,
     results: [{
       value: "m",

--- a/src/common/characters.test.ts
+++ b/src/common/characters.test.ts
@@ -1,4 +1,4 @@
-import { letter, lower, anyChar, upper } from "$common";
+import { anyChar, letter, lower, upper } from "$common";
 import { parseErrors } from "../errors.ts";
 import { assertEquals } from "@std/assert";
 

--- a/src/common/characters.ts
+++ b/src/common/characters.ts
@@ -9,18 +9,18 @@ import { updatePosition } from "../utils.ts";
  * @example Non-empty input
  *
  * ```ts
- * const { results } = take.parse("hello");
+ * const { results } = anyChar.parse("hello");
  * // [{value: 'h', remaining: 'ello', ...}]
  * ```
  *
  * @example Empty input
  *
  * ```ts
- * const { message } = take.parse("");
+ * const { message } = anyChar.parse("");
  * // "Unexpected end of input"
  * ```
  */
-export const take: Parser<string> = createParser(
+export const anyChar: Parser<string> = createParser(
   (input, position) => {
     if (input.length === 0) {
       return {

--- a/src/core/fail.test.ts
+++ b/src/core/fail.test.ts
@@ -1,10 +1,10 @@
 import { assertEquals } from "@std/assert";
 import { fail } from "$core";
-import { take } from "$common";
+import { anyChar } from "$common";
 
 Deno.test("fail", () => {
-  assertEquals(fail.flatMap(() => take).parse("m"), fail.parse("m"));
-  assertEquals(take.flatMap(() => fail).parse("m"), {
+  assertEquals(fail.flatMap(() => anyChar).parse("m"), fail.parse("m"));
+  assertEquals(anyChar.flatMap(() => fail).parse("m"), {
     success: false,
     message: "",
     position: {

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -4,7 +4,7 @@ import {
   letter,
   literal,
   number,
-  take,
+  anyChar,
   token,
   whitespace,
 } from "$common";
@@ -52,7 +52,7 @@ Deno.test("fallback", () => {
 });
 
 Deno.test("filter", () => {
-  const even = take.filter((r) => /^[02468]/.test(r)).error(
+  const even = anyChar.filter((char) => /^[02468]/.test(char)).error(
     "Expected an even number",
   );
 
@@ -151,7 +151,7 @@ Deno.test("skipLeading", () => {
 Deno.test("parseOrThrow", () => {
   const thrw = seq(number, literal("then"), number);
 
-  assertEquals(take.parseOrThrow("monad"), "m");
+  assertEquals(anyChar.parseOrThrow("monad"), "m");
 
   assertThrows(() => (thrw.parseOrThrow("1 next 2")));
 

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -1,10 +1,10 @@
 import { alt, seq } from "$combinators";
 import {
+  anyChar,
   digit,
   letter,
   literal,
   number,
-  anyChar,
   token,
   whitespace,
 } from "$common";

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -194,7 +194,7 @@ export class Parser<T> {
    *
    * ```ts
    * const isVowel = (char) => ["a", "e", "i", "o", "u", "y"].includes(char);
-   * const vowel = take.filter(isVowel).error("Expected a vowel");
+   * const vowel = anyChar.filter(isVowel).error("Expected a vowel");
    *
    * const { results } = vowel.parse("a");
    * // [{value: 'a', remaining: '', ...}]


### PR DESCRIPTION
This is more desciptive, and more precise than `any` which could imply "anything", as the parser still fails is the input is not a character (if it's empty)

